### PR TITLE
Convert user-input from uppercase to lowercase

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -17,4 +17,4 @@ then
 	rm gmd-cmd.o
 fi
 
-make all KEY=$1
+make all KEY=`echo $1|tr '[A-Z]' '[a-z]'`


### PR DESCRIPTION
Using uppercase letters in key fails to generate a working binary; converting all letters to lowercase fixes it.
