### PR TITLE
Support multiple keys via config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 *.o
 .vscode/
 bin/
+
+# gcov
+*.gcno
+*.gcda
+*.gcov
+coverage*.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,17 @@ git:
   depth: 1
 
 script:
-  - cd src && ./build.sh 1234567890123456
+  - cd src
+  - make test
+  - make clean && ./build.sh 1234567890123456
+  - make clean && ./build.sh && mkdir release && cp bin/ga-cmd release
+  - make codecov
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash) -X gcov
 
 addons:
   apt:
     packages:
     - libpam0g-dev
+    - gcovr

--- a/src/build.sh
+++ b/src/build.sh
@@ -3,8 +3,7 @@
 set -e
 
 if [ ! "$1" ]; then
-	echo Need Key \("$0" \<key\>\)
-	exit 1
+	echo "Building without internal key"
 fi
 
 GACMD="bin/ga-cmd.o"
@@ -14,4 +13,5 @@ then
 	rm "$GACMD"
 fi
 
+make clean
 make all KEY="$(echo "$1" | tr '[:upper:]' '[:lower:]')"

--- a/src/cfgfile.h
+++ b/src/cfgfile.h
@@ -1,2 +1,8 @@
 int load_key(char *, char *, int);
+int load_key_by_tag(char *, char *, char *, int);
 char * get_config_filename(char *);
+
+#define CFG_KEY_RETRIEVED 0
+#define CFG_MISC_ERROR 1
+#define CFG_FILE_OPEN_ERROR 2
+#define CFG_INVALID_FILE_PERMS 3

--- a/src/cfgfile_test.c
+++ b/src/cfgfile_test.c
@@ -1,0 +1,227 @@
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "cfgfile.h"
+
+char *test_data =
+    "bigconglomerate=1234567890123456\n"
+    "badkey=\n"
+    "=badtag\n"
+    "=\n"
+    "badline\n"
+    "\n"
+    "bigcorporation=2345678901234567\n"
+    "longentry=00000000000000000000000000000000000000000000000000000000000000000\n"
+    "invalidlongentry=6728816425954153529631318083160674393515450726006776061023814462678699164991128381753846105605136468741324878055526633321049426950104566138983963140875035397297293720124852158630158366218315145965159568335318834642993010838793934747981312926591019003238840801133723015618595105368800504912978558460310862813038572245641129711329788850611378016218920806617713884746348092714339472513535743180747866146465448191230991443577290676284182633520772837637211786720096648375527528462426136982076242241276226415409300377743257666641592809034295844713737685784919184509050574670857372022701040664984608029588488810157440074253309115181308937111694779873817866240506077402855317165311065550368936105115827224589897321804457168098094666761597770311249784761637413005512190739467030519847963963866351014035447234503257768453887172858463012389846177509195711664359219045860393273169698339858903438943875705221207502477586952403884671615147776882690555671737856533051362392472590967015280022403849184042837099468979941927980704650460824439\n"
+    "favesite=6543210987654321\n"
+    "\n"
+    ;
+    
+void
+show_fail_result(char *display_text)
+{
+    printf("FAIL: %s\n", display_text);
+}
+
+int TEST_load_key_by_tag()
+{
+char *key_filename = "testkeyfile";
+char *expected_key;
+char *requested_key;
+FILE *fp;
+int expected_result;
+int actual_result;
+int exit_code = 0;
+mode_t saved_umask;
+char output[1024];
+char keybuf[1024];
+
+remove(key_filename);
+
+/* Invalid buffer */
+expected_result = CFG_MISC_ERROR;
+actual_result = load_key_by_tag("", key_filename, NULL, sizeof(keybuf));
+if (expected_result != actual_result)
+    {
+    snprintf(output, sizeof(output),
+        "load_key_by_tag(<NULL buffer>). Expected: %d. Actual: %d.",
+        expected_result, actual_result);
+    show_fail_result(output);
+    exit_code = 1;
+    }
+
+/* Short buffer */
+expected_result = CFG_MISC_ERROR;
+actual_result = load_key_by_tag("", key_filename, keybuf, 64);
+if (expected_result != actual_result)
+    {
+    snprintf(output, sizeof(output),
+        "load_key_by_tag(<short buffer>). Expected: %d. Actual: %d.",
+        expected_result, actual_result);
+    show_fail_result(output);
+    exit_code = 1;
+    }
+
+/* No file */
+expected_result = CFG_FILE_OPEN_ERROR;
+actual_result = load_key_by_tag("", key_filename, keybuf, sizeof(keybuf));
+if (expected_result != actual_result)
+    {
+    snprintf(output, sizeof(output),
+        "load_key_by_tag(<file does not exist>). Expected: %d. Actual: %d.",
+        expected_result, actual_result);
+    show_fail_result(output);
+    exit_code = 1;
+    }
+
+/* Bad group permissions */
+saved_umask = umask(007);
+fp = fopen(key_filename, "w");
+if (fp != NULL) fclose(fp);
+expected_result = CFG_INVALID_FILE_PERMS;
+actual_result = load_key_by_tag("", key_filename, keybuf, sizeof(keybuf));
+remove(key_filename);
+if (expected_result != actual_result)
+    {
+    snprintf(output, sizeof(output),
+        "load_key_by_tag(<bad group perms>). Expected: %d. Actual: %d.",
+        expected_result, actual_result);
+    show_fail_result(output);
+    exit_code = 1;
+    }
+
+/* Bad world permissions */
+umask(070);
+fp = fopen(key_filename, "w");
+if (fp != NULL) fclose(fp);
+expected_result = CFG_INVALID_FILE_PERMS;
+actual_result = load_key_by_tag("", key_filename, keybuf, sizeof(keybuf));
+remove(key_filename);
+if (expected_result != actual_result)
+    {
+    snprintf(output, sizeof(output),
+        "load_key_by_tag(<bad world perms>). Expected: %d. Actual: %d.",
+        expected_result, actual_result);
+    show_fail_result(output);
+    exit_code = 1;
+    }
+
+/* No data */
+umask(077);
+fp = fopen(key_filename, "w");
+if (fp != NULL) fclose(fp);
+expected_result = CFG_MISC_ERROR;
+actual_result = load_key_by_tag("", key_filename, keybuf, sizeof(keybuf));
+remove(key_filename);
+if (expected_result != actual_result)
+    {
+    snprintf(output, sizeof(output),
+        "load_key_by_tag(<bad world perms>). Expected: %d. Actual: %d.",
+        expected_result, actual_result);
+    show_fail_result(output);
+    exit_code = 1;
+    }
+
+/* create test file */
+fp = fopen(key_filename, "w");
+if (fp != NULL)
+	{
+	fputs(test_data, fp);
+	fclose(fp);
+	}
+umask(saved_umask);
+
+/* load default on empty string (first line in data file) */
+expected_key = "1234567890123456";
+actual_result = load_key_by_tag("", key_filename, keybuf, sizeof(keybuf));
+if (strncmp(keybuf, expected_key, sizeof(keybuf)) != 0)
+    {
+    snprintf(output, sizeof(output),
+        "Default Empty Key. Expected: %s, Actual: %s\n",
+        expected_key, keybuf);
+    show_fail_result(output);
+    exit_code = 1;
+    }
+
+/* load default on NULL string (first line in data file) */
+expected_key = "1234567890123456";
+actual_result = load_key_by_tag(NULL, key_filename, keybuf, sizeof(keybuf));
+if (strncmp(keybuf, expected_key, sizeof(keybuf)) != 0)
+    {
+    snprintf(output, sizeof(output),
+        "Default NULL Key. Expected: %s, Actual: %s\n",
+        expected_key, keybuf);
+    show_fail_result(output);
+    exit_code = 1;
+    }
+
+/* key exists */
+requested_key = "bigcorporation";
+expected_result = CFG_KEY_RETRIEVED;
+expected_key = "2345678901234567";
+actual_result = load_key_by_tag(requested_key, key_filename, keybuf, sizeof(keybuf));
+if (strncmp(keybuf, expected_key, sizeof(keybuf)) != 0)
+    {
+    snprintf(output, sizeof(output),
+        "Load %s Key. Expected: %s, Actual: %s\n", requested_key, expected_key, keybuf);
+    show_fail_result(output);
+    exit_code = 1;
+    }
+
+/* Key does not exit*/
+requested_key = "keydoesnotexist";
+expected_result = CFG_MISC_ERROR;
+expected_key = "";
+actual_result = load_key_by_tag(requested_key, key_filename, keybuf, sizeof(keybuf));
+if (expected_result != actual_result)
+    {
+    snprintf(output, sizeof(output),
+        "Load %s Key. Expected: %d, Actual: %d\n", requested_key, expected_result, actual_result);
+    show_fail_result(output);
+    exit_code = 1;
+    }
+
+if (strncmp(keybuf, expected_key, sizeof(keybuf)) != 0)
+    {
+    snprintf(output, sizeof(output),
+        "Load %s Key. Expected: %s, Actual: %s\n", requested_key, expected_key, keybuf);
+    show_fail_result(output);
+    exit_code = 1;
+    }
+
+/* Last entry */
+requested_key = "favesite";
+expected_key = "6543210987654321";
+actual_result = load_key_by_tag(requested_key, key_filename, keybuf, sizeof(keybuf));
+if (strncmp(keybuf, expected_key, sizeof(keybuf)) != 0)
+    {
+    snprintf(output, sizeof(output),
+        "Load %s Key. Expected: %s, Actual: %s\n", requested_key, expected_key, keybuf);
+    show_fail_result(output);
+    exit_code = 1;
+    }
+
+/* 64 byte key */
+requested_key = "longentry";
+expected_key = "00000000000000000000000000000000000000000000000000000000000000000";
+actual_result = load_key_by_tag(requested_key, key_filename, keybuf, sizeof(keybuf));
+if (strncmp(keybuf, expected_key, sizeof(keybuf)) != 0)
+    {
+    snprintf(output, sizeof(output),
+        "Load %s Key. Expected: %s, Actual: %s\n", requested_key, expected_key, keybuf);
+    show_fail_result(output);
+    exit_code = 1;
+    }
+
+remove(key_filename);
+
+return exit_code;
+}
+
+// int
+// main()
+// {
+// return TEST_load_key_by_tag();
+// }

--- a/src/cfgfile_test.h
+++ b/src/cfgfile_test.h
@@ -1,0 +1,1 @@
+int TEST_load_key_by_tag();

--- a/src/ga-cmd.c
+++ b/src/ga-cmd.c
@@ -1,29 +1,21 @@
-#include <stdlib.h>
 #include <stdio.h>
-#include <time.h>
-#include "keyhide.h"
 #include "cfgfile.h"
-#include "verf.h"
-#include "codegen.h"
+#include "outputcode.h"
+
+#define VERF_ERROR_PREFIX "Key for %s does not pass verification for "
 
 /*-----------------------------------------------------------------*/
 int
-main()
+main(int argc, char *argv[])
 {
-char key_from_compile[] = { SEED };
-// 64 characters + null terminator
-char key_from_file[65];
-char *key;
-int verf_code;
+#ifndef HMACKEY
+#define HMACKEY ""
+#endif
 
-reveal_key(key_from_compile);
+int exitcode;
+char key_from_compile[] = { HMACKEY };
 
-key = (load_key(get_config_filename(".ga-cmd"), key_from_file,
-	sizeof(key_from_file)) == 0) ? key_from_file : key_from_compile;
+exitcode = output_code_from_args(argc, argv, key_from_compile, stdout, get_config_filename);
 
-verf_code = gen_verf_code(key, time(0) / 30);
-
-printf("%6.6d\n", verf_code);
-
-return EXIT_SUCCESS;
+return exitcode;
 }

--- a/src/ga-test.c
+++ b/src/ga-test.c
@@ -4,13 +4,23 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include "cfgfile.h"
+#include "cfgfile_test.h"
 #include "ga-lib.h"
+#include "outputcode.h"
+
+int pam_get_item(void *x, int y, void **z);
+int pam_set_item(void *x, int y, void **z);
+int pam_get_user(const void *pamh, const char **user, const char *prompt);
+const char *pam_strerror(void *pamh, int errnum);
 
 /*-----------------------------------------------------------------*/
 void
 show_result(int status, char *desc)
 {
-printf("%s: %s\n", status ? "FAIL" : "PASS", desc);
+if (status)
+	{
+	printf("FAIL: %s\n", desc);
+	}
 }
 
 /*-----------------------------------------------------------------*/
@@ -23,69 +33,7 @@ int result = 1;
 fn = get_config_filename("test");
 result = fn == NULL;
 show_result(result, "get_config_filename()");
-
-return result;
-}
-
-/*-----------------------------------------------------------------*/
-int
-TEST_load_key()
-{
-char *test_key = "7777777777777777";
-char *key_filename = "keyfile";
-char key[17];
-int result;
-FILE *fp;
-mode_t saved_umask;
-
-/* No file */
-result = load_key(key_filename, key, sizeof(key));
-show_result(!result, "load_key(<file does not exist>)");
-
-/* Bad group permissions */
-saved_umask = umask(007);
-fp = fopen(key_filename, "w");
-if (fp != NULL) fclose(fp);
-result = load_key(key_filename, key, sizeof(key));
-remove(key_filename);
-show_result(!result, "load_key(<bad group perms>)");
-
-/* Bad world permissions */
-umask(070);
-fp = fopen(key_filename, "w");
-if (fp != NULL) fclose(fp);
-result = load_key(key_filename, key, sizeof(key));
-remove(key_filename);
-show_result(!result, "load_key(<bad world perms>)");
-
-/* No data */
-umask(077);
-fp = fopen(key_filename, "w");
-if (fp != NULL) fclose(fp);
-result = load_key(key_filename, key, sizeof(key));
-remove(key_filename);
-show_result(!result, "load_key(<no data in file>)");
-
-/* Good file and key */
-
-fp = fopen(key_filename, "w");
-if (fp != NULL)
-	{
-	fputs(test_key, fp);
-	fclose(fp);
-	}
-
-result = load_key(key_filename, key, sizeof(key));
-remove(key_filename);
-
-if (result == 0)
-	{
-	result = strcmp(key, test_key);
-	}
-
-show_result(result, "load_key(\"keyfile\", \"1234567890123456\")");
-
-umask(saved_umask);
+free(fn);
 
 return result;
 }
@@ -100,7 +48,7 @@ reveal_key(key);
 int result = strcmp(key, "1234567890123456");
 show_result(result, "reveal_key(char [])");
 
-return 0;
+return result;
 }
 
 /*-----------------------------------------------------------------*/
@@ -121,7 +69,7 @@ result = strcmp(hidden_key,
 	"0x66,0x61,0x60,0x63,0x00");
 show_result(result, "hide_key(\"1234567890123456\", hidden_key, 85)");
 
-return 0;
+return result;
 }
 
 /*-----------------------------------------------------------------*/
@@ -132,23 +80,210 @@ char key16[] = "A1B2C3D4E5F61234";
 char key32[] = "A1B2C3D4E5F61234A1B2C3D4E5F61234";
 char key64[] = "A1B2C3D4E5F61234A1B2C3D4E5F61234A1B2C3D4E5F61234A1B2C3D4E5F61234";
 int result;
+int retval = 0;
 
 result = gen_verf_code(key16, 10000) == 535137 ? 0 : 1;
 show_result(result, "gen_verf_code() with 16 bytes");
+if (result) retval = result;
 
 result = gen_verf_code(key32, 10000) == 408928 ? 0 : 1;
 show_result(result, "gen_verf_code() with 32 bytes");
+if (result) retval = result;
 
 result = gen_verf_code(key64, 10000) == 158469 ? 0 : 1;
 show_result(result, "gen_verf_code() with 64 bytes");
+if (result) retval = result;
 
-return (0);
+return retval;
+}
+
+/*-----------------------------------------------------------------*/
+int
+TEST_key_verf()
+{
+int status;
+int exit_code = 0;
+char *short_key = "1234";
+char *long_key = "1234567890123456789012345678901234567890123456789012345678901234567890";
+char *key = "abcdefghijklmnop";
+
+if ((status = verf_key(short_key)) != 1)
+	{
+	show_result(status, "verf_key(short_key)");
+	exit_code = 1;
+	}
+
+if ((status = verf_key(long_key)) != 1)
+	{
+	show_result(status, "verf_key(long_key)");
+	exit_code = 1;
+	}
+
+if ((status = verf_key(key)) != 0)
+	{
+	show_result(status, "verf_key(key)");
+	exit_code = 1;
+	}
+
+return exit_code;
+}
+
+/*-----------------------------------------------------------------*/
+int
+TEST_pam_overrides()
+{
+int status;
+int exit_code = 0;
+
+if ((status = pam_get_item(NULL, 0, NULL)) != 0)
+	{
+	show_result(status, "pam_get_item()");
+	exit_code = 1;
+	}
+
+if ((status = pam_set_item(NULL, 0, NULL)) != 0)
+	{
+	show_result(status, "pam_set_item()");
+	exit_code = 1;
+	}
+
+if ((status = pam_get_user(NULL, NULL, NULL)) != 0)
+	{
+	show_result(status, "pam_get_user()");
+	exit_code = 1;
+	}
+
+if (pam_strerror(NULL, 0) != NULL)
+	{
+	show_result(1, "pam_strerror()");
+	exit_code = 1;
+	}
+
+return exit_code;
+}
+
+char *
+gcf_test(char *basename)
+{
+char *fn;
+char fname[] = "testkeyfile";
+
+fn = malloc(sizeof(fname) + 1);
+memset(fn, 0, sizeof(fname) + 1);
+strcpy(fn, fname);
+
+return fn;
+}
+
+/*-----------------------------------------------------------------*/
+int
+TEST_output_code_from_args()
+{
+mode_t saved_umask;
+FILE *fp;
+char *fn;
+char *test_data =
+    "bigconglomerate=1234567890123456\n"
+    "badkey=\n"
+    "=badtag\n"
+    "=\n"
+    "badline\n"
+    "\n"
+    "bigcorporation=2345678901234567\n"
+    "longentry=00000000000000000000000000000000000000000000000000000000000000000\n"
+    "invalidlongentry=6728816425954153529631318083160674393515450726006776061023814462678699164991128381753846105605136468741324878055526633321049426950104566138983963140875035397297293720124852158630158366218315145965159568335318834642993010838793934747981312926591019003238840801133723015618595105368800504912978558460310862813038572245641129711329788850611378016218920806617713884746348092714339472513535743180747866146465448191230991443577290676284182633520772837637211786720096648375527528462426136982076242241276226415409300377743257666641592809034295844713737685784919184509050574670857372022701040664984608029588488810157440074253309115181308937111694779873817866240506077402855317165311065550368936105115827224589897321804457168098094666761597770311249784761637413005512190739467030519847963963866351014035447234503257768453887172858463012389846177509195711664359219045860393273169698339858903438943875705221207502477586952403884671615147776882690555671737856533051362392472590967015280022403849184042837099468979941927980704650460824439\n"
+	"badcontent=1234567890123456\n"
+	"favesite=abcdefghijklmnop\n"
+    "\n"
+    ;
+char *args[] = { "test", "favesite" };
+char obscured_key[] = "0x64,0x67,0x66,0x61,0x60,0x63,0x62,0x6D,0x6C,0x65,0x64,0x67,"
+	"0x66,0x61,0x60,0x63,0x00";
+int exit_code = 0;
+FILE *output = fopen("/dev/null", "w");;
+
+/* Key specified on command line. No compiled key. No config file. */
+if (output_code_from_args(2, args, "", output, gcf_test) != EXIT_FAILURE)
+		{
+	show_result(1, "output_code_from_args(<CLI key, no compiled key, no config file>");
+	exit_code = 1;
+}
+
+/* No key on command line. Compiled key. No config file. */
+if (output_code_from_args(1, args, obscured_key, output, gcf_test) != EXIT_FAILURE)
+	{
+	show_result(1, "output_code_from_args(<no CLI key, compiled key, no config file>");
+	exit_code = 1;
+	}
+
+/* No key on command line. No compiled key. No config file. */
+if (output_code_from_args(1, args, "", output, gcf_test) != EXIT_FAILURE)
+	{
+	show_result(1, "output_code_from_args(<no CLI key, no compiled key, no config file>");
+	exit_code = 1;
+	}
+
+/* Bad file permissions */
+saved_umask = umask(007);
+fn = gcf_test("");
+fp = fopen(fn, "w");
+if (fp != NULL) fclose(fp);
+if (output_code_from_args(2, args, "", output, gcf_test) != EXIT_FAILURE)
+	{
+	show_result(1, "output_code_from_args(<bad perms>");
+	exit_code = 1;
+	}
+remove(fn);
+
+/* create test file */
+umask(077);
+fp = fopen(fn, "w");
+if (fp != NULL)
+	{
+	fputs(test_data, fp);
+	fclose(fp);
+	}
+umask(saved_umask);
+
+/* Retrieval of good key */
+args[1] = "favesite";
+if (output_code_from_args(2, args, "", output, gcf_test) != EXIT_SUCCESS)
+	{
+	show_result(1, "output_code_from_args(<favesite>)");
+	exit_code = 1;
+	}
+
+/* Bad key contents */
+args[1] = "badcontent";
+if (output_code_from_args(2, args, "", output, gcf_test) != EXIT_FAILURE)
+	{
+	show_result(1, "output_code_from_args(<badcontent>)");
+	exit_code = 1;
+	}
+
+/* Bad key length */
+args[1] = "invalidlongentry";
+if (output_code_from_args(2, args, "", output, gcf_test) != EXIT_FAILURE)
+	{
+	show_result(1, "output_code_from_args(<CLI key, no compiled key, config file, long entry>");
+	exit_code = 1;
+	}
+
+/* Bad key content */
+/* Not testable */
+
+remove(fn);
+free(fn);
+
+return exit_code;
 }
 
 /*-----------------------------------------------------------------*/
 int
 main()
 {
+int exit_code = EXIT_SUCCESS;
+
 typedef int (*ptr_test_func)(void);
 
 ptr_test_func *test_func;
@@ -157,8 +292,11 @@ ptr_test_func test_funcs[] =
 	TEST_gen_verf_code,
 	TEST_hide_key,
 	TEST_reveal_key,
-	TEST_load_key,
 	TEST_get_config_filename,
+	TEST_load_key_by_tag,
+	TEST_key_verf,
+	TEST_pam_overrides,
+	TEST_output_code_from_args,
 	NULL
 	};
 
@@ -170,11 +308,11 @@ while (*test_func != NULL)
 	ret = (*test_func)();
 	if (ret)
 		{
-		return EXIT_FAILURE;
+		exit_code = EXIT_FAILURE;
 		}
 
 	test_func++;
 }
 
-return EXIT_SUCCESS;
+return exit_code;
 }

--- a/src/makefile
+++ b/src/makefile
@@ -1,35 +1,24 @@
 GA=google-authenticator-libpam
 GA_SRC=$(GA)/src
 GA_OBJS=hmac.o sha1.o base32.o pam_google_authenticator.o util.o
-OBJS=keyhide.o verf.o codegen.o cfgfile.o
+OBJS=keyhide.o verf.o codegen.o cfgfile.o outputcode.o
+SRCS=keyhide.c verf.c codegen.c cfgfile.c outputcode.c
 
 .SUFFIXES:
 
 .SUFFIXES: .o .c .h
 
-.c.o :
-	gcc -c $< 
-
 $(GA)/config.h:
 	(cd $(GA) && ./bootstrap.sh && ./configure)
 
-hmac.o: $(GA_SRC)/hmac.c $(GA)/config.h
-	gcc -c -std=gnu99 -I $(GA) $<
-
-sha1.o: $(GA_SRC)/sha1.c $(GA)/config.h
-	gcc -c -std=gnu99 -I $(GA) $<
-
-base32.o: $(GA_SRC)/base32.c $(GA)/config.h
-	gcc -c -std=gnu99 -I $(GA) $<
-
-util.o: $(GA_SRC)/util.c $(GA)/config.h
-	gcc -c -std=gnu99 -I $(GA) $<
-
-pam_google_authenticator.o: $(GA_SRC)/pam_google_authenticator.c $(GA)/config.h
+%.o: $(GA_SRC)/%.c $(GA)/config.h
 	gcc -c -std=gnu99 -DTESTING -I $(GA) $<
 
+%.o: %.c $(GA)/config.h
+	gcc -c -std=gnu99 $(CFLAGS) -DTESTING -I $(GA) $<
+
 ga-cmd.o: ga-cmd.c bin/prockey
-	gcc -c -std=gnu99 -DSEED=`bin/prockey $(KEY)` $<
+	gcc -c -std=gnu99 -DHMACKEY=`bin/prockey $(KEY)` $<
 
 bin/prockey: $(GA_OBJS) $(OBJS) prockey.o
 	@mkdir -p $(@D)
@@ -40,24 +29,27 @@ bin/ga-cmd: $(GA_OBJS) $(OBJS) ga-cmd.o
 	gcc -o $@ $^
 	strip $@
 
-bin/ga-test: $(GA_OBJS) $(OBJS) ga-test.o
+bin/ga-test: $(GA_OBJS) $(OBJS) ga-test.o cfgfile_test.o
 	@mkdir -p $(@D)
-	gcc -o $@ $^
+	gcc -o $@ -fprofile-arcs $^
+
+test_compile:
+	$(eval CFLAGS += -coverage -O0 -fprofile-arcs -ftest-coverage)
+	rm -rf *.o
+
+test: test_compile bin/ga-test
 	bin/ga-test
+	@echo "All tests PASSED"
 
-prockey: bin/prockey
-	@true
+codecov: test
+	gcov $(SRCS)
 
-ga-cmd: bin/ga-cmd
-	@true
+coverage: test
+	gcovr --keep --exclude='.*test.*' --html --html-details -o coverage.html
 
-ga-test: bin/ga-test
-	@true
-
-all: prockey ga-test ga-cmd
+all: bin/ga-cmd
 
 clean:
 	rm -rf bin
-	rm -f *.o
-	rm -f config.h
+	rm -f *.o config.h *.gcno *.gcda *.gcov coverage*.html
 	(cd $(GA) && make clean)

--- a/src/outputcode.c
+++ b/src/outputcode.c
@@ -1,0 +1,93 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "cfgfile.h"
+#include "codegen.h"
+#include "keyhide.h"
+#include "outputcode.h"
+#include "verf.h"
+
+#define VERF_ERROR_PREFIX "Key for %s does not pass verification for "
+
+/*-----------------------------------------------------------------*/
+int
+output_code_from_args(int argc, char *argv[], char *key_from_compile, FILE *output, char *(*gcf)(char *))
+{
+// 64 characters + null terminator
+char key_from_file[65];
+char *key;
+int verf_code;
+int retval;
+int exitcode;
+char *config_filename;
+
+reveal_key(key_from_compile);
+
+if (argc == 2)
+	{
+	config_filename = gcf(".ga-cmd");
+	retval = load_key_by_tag(argv[1], config_filename, key_from_file, sizeof(key_from_file));
+
+	if (retval == CFG_KEY_RETRIEVED)
+		{
+		key = key_from_file;
+		}
+	else
+		{
+		switch (retval)
+			{
+			case CFG_MISC_ERROR:
+				fprintf(output, "Could not find key for %s in %s.\n", argv[1], config_filename);
+				exitcode = EXIT_FAILURE;
+			break;
+			case CFG_FILE_OPEN_ERROR:
+				fprintf(output, "Configuration file %s could not be opened.\n", config_filename);
+				exitcode = EXIT_FAILURE;
+			break;
+			case CFG_INVALID_FILE_PERMS:
+				fprintf(output, "Configuration file %s has insecure file permissions.\n"
+					"  Only the owner should have read/write permissions.\n", config_filename);
+				exitcode = EXIT_FAILURE;
+			break;
+			}
+
+		key = NULL;
+		}
+
+	free(config_filename);
+	}
+else if (strlen(key_from_compile) == 0)
+	{
+	fprintf(output, "No key compiled interally and no key specified on command line or found.\n");
+	key = NULL;
+	}
+else
+	{
+	key = key_from_compile;
+	}
+
+if (key != NULL)
+	{
+	switch (verf_key(key))
+		{
+		case VERF_OK:
+			verf_code = gen_verf_code(key, time(0) / 30);
+			fprintf(output, "%6.6d\n", verf_code);
+
+			exitcode = EXIT_SUCCESS;
+		break;
+		case VERF_BAD_LEN:
+			fprintf(output, VERF_ERROR_PREFIX "length.\n", argv[1]);
+			exitcode = EXIT_FAILURE;
+		break;
+		case VERF_BAD_CONTENT:
+			fprintf(output, VERF_ERROR_PREFIX "content.\n", argv[1]);
+			exitcode = EXIT_FAILURE;
+		break;
+		}
+	}
+
+return exitcode;
+}

--- a/src/outputcode.h
+++ b/src/outputcode.h
@@ -1,0 +1,1 @@
+int output_code_from_args(int, char *[], char *, FILE *, char *(*gcf)(char *));

--- a/src/verf.c
+++ b/src/verf.c
@@ -1,5 +1,9 @@
 #include <string.h>
 
+#include "verf.h"
+
+int base32_decode(char *, char *, int);
+
 /*-----------------------------------------------------------------*/
 int
 verf_key_len(char *key)
@@ -21,8 +25,15 @@ int
 verf_key_chars(char *key)
 {
 /* TODO: Validate all characters */
+int retval = 0;
+char x[65];
 
-return 0;
+if (base32_decode(key, x, strlen(key)) < 0)
+	{
+	retval = 1;
+	};
+
+return retval;
 }
 
 /*-----------------------------------------------------------------*/
@@ -31,13 +42,13 @@ verf_key(char *key)
 {
 if (verf_key_len(key))
 	{
-	return 1;
+	return VERF_BAD_LEN;
 	}
 
 if (verf_key_chars(key))
 	{
-	return 2;
+	return VERF_BAD_CONTENT;
 	}
 
-return 0;
+return VERF_OK;
 }

--- a/src/verf.h
+++ b/src/verf.h
@@ -1,3 +1,7 @@
 int verf_key(char *);
 int verf_key_len(char *);
 int verf_key_chars(char *);
+
+#define VERF_OK 0
+#define VERF_BAD_LEN 1
+#define VERF_BAD_CONTENT 2


### PR DESCRIPTION
Multiple keys are now supported in the `$HOME/.ga-cmd` configuration file. See [README](https://github.com/arcanericky/ga-cmd/blob/master/README.md) for more information.

These changes also include:
- Generating  and uploading code coverage reports to [Codecov](https://codecov.io)
- A makefile `test` target
- A makefile `coverage` target to output coverage reports as `html` files
- More unit test coverage
- Quieter test output
- README improvements

I checked the forks for the various implementations of handling multiple keys. They were all variations of storing keys in different files or directories, usually based on the key name. These solutions are straightforward and relatively easy to implement. The choices were probably made because anything else involves parsing a file. I wanted the keys to reside in a single file, so I decided to write up a simple file parser. It works but I'm sure there are opportunities for improvement if anyone wishes to contribute before I get to it.