### PR TITLE
Resolve XOR resulting in encoding a "\0" byte

### DIFF
--- a/src/ga-test.c
+++ b/src/ga-test.c
@@ -40,34 +40,42 @@ return result;
 
 /*-----------------------------------------------------------------*/
 int
-TEST_reveal_key()
-{
-char key[] = { 0x64,0x67,0x66,0x61,0x60,0x63,0x62,0x6D,0x6C,0x65,0x64,0x67,
-	0x66,0x61,0x60,0x63,0x00 };
-reveal_key(key);
-int result = strcmp(key, "1234567890123456");
-show_result(result, "reveal_key(char [])");
-
-return result;
-}
-
-/*-----------------------------------------------------------------*/
-int
-TEST_hide_key()
+TEST_hide_and_reveal_key()
 {
 int result;
-char hidden_key[85];
+char test_key[] = "1234567890123456";
+char hidden_key[sizeof(test_key) * 5];
+
+char test_key_long[] = "ABCDEFGHIJLMNOPQRSTUVWXYZ234567";
+char hidden_key_long[sizeof(hidden_key) * 5];
+
+char *hkld_key_stepper, *hidden_key_stepper;
+int key_byte;
+char hidden_key_long_decoded[sizeof(test_key_long)];
 
 /* Test for computing bytes needed */
-result = hide_key("1234567890123456", NULL, 0) == 85 ? 0 : 1;
+result = hide_key(test_key, NULL, 0) == sizeof(test_key) * 5 ? 0 : 1;
 show_result(result, "hide_key(\"1234567890123456\", NULL, 0)");
 
-/* Test for generating obfuscated key */
-hide_key("1234567890123456", hidden_key, sizeof(hidden_key));
-result = strcmp(hidden_key,
-	"0x64,0x67,0x66,0x61,0x60,0x63,0x62,0x6D,0x6C,0x65,0x64,0x67,"
-	"0x66,0x61,0x60,0x63,0x00");
-show_result(result, "hide_key(\"1234567890123456\", hidden_key, 85)");
+/* Test all valid key characters */
+hide_key(test_key_long, hidden_key_long, sizeof(hidden_key_long));
+
+hkld_key_stepper = hidden_key_long_decoded;
+hidden_key_stepper = hidden_key_long;
+do
+	{
+	sscanf(hidden_key_stepper, "%x", &key_byte);
+	*hkld_key_stepper++ = key_byte;
+	hidden_key_stepper += 5;
+	} while (key_byte != 0);
+
+reveal_key(hidden_key_long_decoded);
+
+if (strcmp(test_key_long, hidden_key_long_decoded) != 0)
+	{
+	result = 1;
+	show_result(result, "hide_key()/reveal_key() all valid characters");
+	}
 
 return result;
 }
@@ -290,8 +298,7 @@ ptr_test_func *test_func;
 ptr_test_func test_funcs[] =
 	{
 	TEST_gen_verf_code,
-	TEST_hide_key,
-	TEST_reveal_key,
+	TEST_hide_and_reveal_key,
 	TEST_get_config_filename,
 	TEST_load_key_by_tag,
 	TEST_key_verf,

--- a/src/keyhide.c
+++ b/src/keyhide.c
@@ -1,7 +1,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#define SECRETKEY 0b01010101
+#define SECRETKEY 0b00010101
 
 /*-----------------------------------------------------------------*/
 int


### PR DESCRIPTION
A nice observation as @forevernull pointed out long ago in PR #16 that XORing 'U' (binary value 0b01010101 with the obfuscating byte of 0b01010101 results in a '\0' character that in turn blows up the end-of-string handling bits of code.

This change uses a new obfuscating byte value along with unit tests to cover all the allowed bytes in a key. The unit test hides then reveals the key to show it works with all valid bytes.

Resolves #15