### PR TITLE
Inject and display version info

### DIFF
--- a/src/ga-cmd.c
+++ b/src/ga-cmd.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include "cfgfile.h"
 #include "outputcode.h"
+#include "version.h"
 
 #define VERF_ERROR_PREFIX "Key for %s does not pass verification for "
 
@@ -12,10 +13,17 @@ main(int argc, char *argv[])
 #define HMACKEY ""
 #endif
 
-int exitcode;
+#ifndef VERSION
+#define VERSION "unknown"
+#endif
+
+int exitcode = 0;
 char key_from_compile[] = { HMACKEY };
 
-exitcode = output_code_from_args(argc, argv, key_from_compile, stdout, get_config_filename);
+if (!version_option(argc, argv, VERSION, stdout))
+    {
+    exitcode = output_code_from_args(argc, argv, key_from_compile, stdout, get_config_filename);
+    }
 
 return exitcode;
 }

--- a/src/ga-test.c
+++ b/src/ga-test.c
@@ -7,6 +7,7 @@
 #include "cfgfile_test.h"
 #include "ga-lib.h"
 #include "outputcode.h"
+#include "version_test.h"
 
 int pam_get_item(void *x, int y, void **z);
 int pam_set_item(void *x, int y, void **z);
@@ -304,7 +305,8 @@ struct test_routine test_routines[] = {
 	{ TEST_load_key_by_tag, "TEST_load_key_by_tag" },
 	{ TEST_key_verf, "TEST_key_verf" },
 	{ TEST_pam_overrides, "TEST_pam_overrides" },
-	{ TEST_output_code_from_args, "TEST_output_code_from_args"},
+	{ TEST_output_code_from_args, "TEST_output_code_from_args" },
+	{ TEST_version_option, "TEST_version_option" },
 	{ NULL, NULL }
 };
 

--- a/src/makefile
+++ b/src/makefile
@@ -1,8 +1,8 @@
 GA=google-authenticator-libpam
 GA_SRC=$(GA)/src
 GA_OBJS=hmac.o sha1.o base32.o pam_google_authenticator.o util.o
-OBJS=keyhide.o verf.o codegen.o cfgfile.o outputcode.o
-SRCS=keyhide.c verf.c codegen.c cfgfile.c outputcode.c
+OBJS=keyhide.o verf.o codegen.o cfgfile.o outputcode.o version.o
+SRCS=keyhide.c verf.c codegen.c cfgfile.c outputcode.c version.c
 
 .SUFFIXES:
 
@@ -18,7 +18,7 @@ $(GA)/config.h:
 	gcc -c -std=gnu99 $(CFLAGS) -DTESTING -I $(GA) $<
 
 ga-cmd.o: ga-cmd.c bin/prockey
-	gcc -c -std=gnu99 -DHMACKEY=`bin/prockey $(KEY)` $<
+	gcc -c -std=gnu99 -DHMACKEY=`bin/prockey $(KEY)` -DVERSION=\"$(shell sh scripts/get-version.sh)\" $<
 
 bin/prockey: $(GA_OBJS) $(OBJS) prockey.o
 	@mkdir -p $(@D)
@@ -29,7 +29,7 @@ bin/ga-cmd: $(GA_OBJS) $(OBJS) ga-cmd.o
 	gcc -o $@ $^
 	strip $@
 
-bin/ga-test: $(GA_OBJS) $(OBJS) ga-test.o cfgfile_test.o
+bin/ga-test: $(GA_OBJS) $(OBJS) ga-test.o cfgfile_test.o version_test.o
 	@mkdir -p $(@D)
 	gcc -o $@ -fprofile-arcs $^
 

--- a/src/scripts/get-version.sh
+++ b/src/scripts/get-version.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+VERSION=$(git tag --points-at HEAD | head -1)
+if [ -z "$VERSION" ]; then
+  VERSION=$(git rev-parse HEAD | cut -c 1-7)
+fi
+
+echo $VERSION
+

--- a/src/version.c
+++ b/src/version.c
@@ -1,0 +1,22 @@
+#include <getopt.h>
+#include <stdio.h>
+
+int version_option(int argc, char *argv[], char *version, FILE *fp)
+{
+int f_version = 0;
+int option_index = 0;
+int return_code = 0;
+struct option long_options[] =
+{
+    { "version", no_argument, &f_version, 1 },
+    { NULL, 0, NULL, 0 }
+};
+
+if (getopt_long(argc, argv, "-:v", long_options, &option_index) == 'v' || f_version == 1)
+    {
+    fprintf(fp, "ga-cmd version %s\n", version);
+    return_code = 1;
+    }
+
+return return_code;
+}

--- a/src/version.h
+++ b/src/version.h
@@ -1,0 +1,2 @@
+int version_option(int , char *[], char *, FILE *);
+

--- a/src/version_test.c
+++ b/src/version_test.c
@@ -1,0 +1,44 @@
+#include <getopt.h>
+#include <stdio.h>
+#include "version.h"
+
+int TEST_version_option()
+{
+char *version_string = "test-version";
+char *arg_zero = "test-cmd";
+char *args[] = { arg_zero, "--version" };
+FILE *fp;
+int actual_result;
+int return_code = 0;
+
+fp = fopen("/dev/null", "w");
+
+actual_result = version_option(2, args, version_string, fp);
+if (!actual_result)
+    {
+    printf("FAIL: Version should be shown when --version flag is given\n");
+    return_code = 1;
+    }
+
+optind = 1;
+args[1] = "-v";
+actual_result = version_option(2, args, version_string, fp);
+if (!actual_result)
+    {
+    printf("FAIL: Version should be shown when -v flag is given\n");
+    return_code = 1;
+    }
+
+optind = 1;
+args[1] = NULL;
+actual_result = version_option(1, args, version_string, fp);
+if (actual_result)
+    {
+    printf("FAIL: Version should not be shown when no flag is given\n");
+    return_code = 1;
+    }
+
+fclose (fp);
+
+return return_code;
+}

--- a/src/version_test.h
+++ b/src/version_test.h
@@ -1,0 +1,2 @@
+int TEST_version_option();
+


### PR DESCRIPTION
Determine the executable version and inject it into the `make` process. Display the version when given the `--version` or `-v` option.

### Determine the Version
If a tag exists on the current `HEAD` use it for the version else use the first 7 characters of the current commit ID.

### Inject the Version
Use the `gcc` `-D` option to define the version at compile time.

### Display the Version
Use the format `ga-cmd version <version string>`

Later this can be used as a basis for:
- Creating a release based on the version (`tag`)
- Being able to base bug reports on versions or commit IDs